### PR TITLE
added Makefile to UP3DTOOLS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,15 @@
+TEST
+
+
+
+
+
+
+
+
+
+
+
 # UP3D
 UP 3D Printer Tools
 

--- a/README.md
+++ b/README.md
@@ -1,15 +1,3 @@
-TEST
-
-
-
-
-
-
-
-
-
-
-
 # UP3D
 UP 3D Printer Tools
 

--- a/UP3DTOOLS/Makefile
+++ b/UP3DTOOLS/Makefile
@@ -1,0 +1,36 @@
+CC ?= gcc
+RM ?= rm -rf
+
+CFLAGS += -Os -std=c99 -D_BSD_SOURCE
+# CFLAGS += -D_DEBUG_IN_OUT_
+CFLAGS += -I../UP3DCOMMON/
+CFLAGS += -Wall $(shell pkg-config --cflags libusb-1.0)/..
+
+LDFLAGS += $(shell pkg-config --libs-only-other --libs-only-L libusb-1.0)
+LIBS += $(shell pkg-config --libs-only-l libusb-1.0) -lpthread -lm
+
+SRC_COMMON= ../UP3DCOMMON/up3d.c 
+SRC_COMMON+=../UP3DCOMMON/up3dcomm.c 
+SRC_COMMON+=../UP3DCOMMON/up3ddata.c 
+
+SRC_UPLOAD=upload.c $(SRC_COMMON)
+OBJ_UPLOAD=$(subst .c,.o,$(SRC_UPLOAD))
+
+SRC_SHELL=upshell.c $(SRC_COMMON)
+OBJ_SHELL=$(subst .c,.o,$(SRC_SHELL))
+
+all: up3dload up3dshell
+
+up3dload: $(OBJ_UPLOAD)
+	$(CC) $(CFLAGS) $(LDFLAGS) -o up3dload $(OBJ_UPLOAD) $(LIBS)
+
+up3dshell: $(OBJ_SHELL)
+	$(CC) $(CFLAGS) $(LDFLAGS) -o up3dshell $(OBJ_SHELL) $(LIBS) -lncurses
+
+clean:
+	$(RM) $(OBJ_UPLOAD)
+	$(RM) $(OBJ_SHELL)
+	$(RM) up3dload
+	$(RM) up3dshell
+
+dist-clean: clean

--- a/UP3DTOOLS/Makefile
+++ b/UP3DTOOLS/Makefile
@@ -19,7 +19,10 @@ OBJ_UPLOAD=$(subst .c,.o,$(SRC_UPLOAD))
 SRC_SHELL=upshell.c $(SRC_COMMON)
 OBJ_SHELL=$(subst .c,.o,$(SRC_SHELL))
 
-all: up3dload up3dshell
+SRC_INFO=upinfo.c $(SRC_COMMON)
+OBJ_INFO=$(subst .c,.o,$(SRC_INFO))
+
+all: up3dload up3dshell up3dinfo
 
 up3dload: $(OBJ_UPLOAD)
 	$(CC) $(CFLAGS) $(LDFLAGS) -o up3dload $(OBJ_UPLOAD) $(LIBS)
@@ -27,10 +30,15 @@ up3dload: $(OBJ_UPLOAD)
 up3dshell: $(OBJ_SHELL)
 	$(CC) $(CFLAGS) $(LDFLAGS) -o up3dshell $(OBJ_SHELL) $(LIBS) -lncurses
 
+up3dinfo: $(OBJ_INFO)
+	$(CC) $(CFLAGS) $(LDFLAGS) -o up3dinfo $(OBJ_INFO) $(LIBS)
+
 clean:
 	$(RM) $(OBJ_UPLOAD)
 	$(RM) $(OBJ_SHELL)
+	$(RM) $(OBJ_INFO)
 	$(RM) up3dload
 	$(RM) up3dshell
+	$(RM) up3dinfo
 
 dist-clean: clean

--- a/UP3DTOOLS/Makefile
+++ b/UP3DTOOLS/Makefile
@@ -28,6 +28,10 @@ up3dload: $(OBJ_UPLOAD)
 	$(CC) $(CFLAGS) $(LDFLAGS) -o up3dload $(OBJ_UPLOAD) $(LIBS)
 
 up3dshell: $(OBJ_SHELL)
+	@echo "--------------- FIXME: -lncurses should be in CFLAGS / LDFLAGS / LIBS ??"
+	@echo "--------------- FIXME: -lncurses should be in CFLAGS / LDFLAGS / LIBS ??"
+	@echo "--------------- FIXME: -lncurses should be in CFLAGS / LDFLAGS / LIBS ??"
+	@echo "--------------- FIXME: -lncurses should be in CFLAGS / LDFLAGS / LIBS ??"
 	$(CC) $(CFLAGS) $(LDFLAGS) -o up3dshell $(OBJ_SHELL) $(LIBS) -lncurses
 
 up3dinfo: $(OBJ_INFO)


### PR DESCRIPTION
I added this Makefile (which can be improved) to be able to build the UP3DTOOLS for OpenWrt. 
The OpenWrt Makefile is in another repository: https://github.com/companje/up3dload

I managed to run up3dload and up3dinfo on a TP-Link MR3020. I haven't succeeded in running up3dshell because I'm doing something wrong with the libncurses dependency.