### PR TITLE
Update convg.c to fix MoveL calculation

### DIFF
--- a/UP3DPARSE/convg.c
+++ b/UP3DPARSE/convg.c
@@ -134,9 +134,9 @@ void _dat_cmd_MoveF( float speed1, float pos1, float speed2, float pos2, bool is
 
 void _dat_cmd_MoveL( uint16_t p1, uint16_t p2, int16_t p3, int16_t p4, int16_t p5, int16_t p6, int16_t p7, int16_t p8 )
 {
-  int32_t sx = floor((float)((p3*p1+p6*p1*p1/2))/512);
-  int32_t sy = floor((float)((p4*p1+p7*p1*p1/2))/512);
-  int32_t sa = floor((float)((p5*p1+p8*p1*p1/2))/512);
+  int32_t sx = floor((float)((p3*p1+p6*(p1-1)*p1/2))/512);
+  int32_t sy = floor((float)((p4*p1+p7*(p1-1)*p1/2))/512);
+  int32_t sa = floor((float)((p5*p1+p8*(p1-1)*p1/2))/512);
   double r1 = sx/STEPS_X;
   double r2 = sy/STEPS_Y;
   double r3 = sa/STEPS_E;


### PR DESCRIPTION
This is related to #40 and should be fixed as well, so the tool chain stays consistent.
